### PR TITLE
Fix crash on Add Physical Disk (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,4 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+/.vs

--- a/ISCSIConsole/Win32/SelectPhysicalDiskForm.cs
+++ b/ISCSIConsole/Win32/SelectPhysicalDiskForm.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+using System.IO;
 using System.Text;
 using System.Windows.Forms;
 using DiskAccessLibrary;
@@ -40,9 +41,27 @@ namespace ISCSIConsole
                 item.SubItems.Add(sizeString);
                 if (Environment.OSVersion.Version.Major >= 6)
                 {
-                    bool isOnline = physicalDisk.GetOnlineStatus();
-                    string status = isOnline ? "Online" : "Offline";
-                    item.SubItems.Add(status);
+                    try
+                    {
+                        bool isOnline = physicalDisk.GetOnlineStatus();
+                        string status = isOnline ? "Online" : "Offline";
+                        item.SubItems.Add(status);
+                    } catch (IOException ex)
+                    {
+                        /* GetOnlineStatus() doesn't really pass us the last Win32 error code
+                         * but an error code of 32 (ERROR_SHARING_VIOLATION) is acceptable for
+                         * system disks. (The disk is probably in use by the OS).
+                         * 
+                         * Win32 Error: 32 is "The process cannot access the file because it is being used by another process".
+                         */
+                        if (ex.Message.EndsWith("Win32 Error: 32"))
+                        {
+                            item.SubItems.Add("Unknown");
+                        } else
+                        {
+                            throw ex;
+                        }
+                    }
                 }
                 item.Tag = physicalDisk;
                 listPhysicalDisks.Items.Add(item);


### PR DESCRIPTION
It seems as though #8 was the result of system drives (like the drive your OS is on) being in use when attempting to check the online status. I've added handling for the case of this specific error, but it does not discriminate between system drives and non-system drives. When loading the physical disk form, we catch IOExceptions from GetOnlineStatus, check if they're a result of system error 32, and set the status to "Unknown" as opposed to "Online" or "Offline". If the exception is not because of system error 32, we rethrow the exception